### PR TITLE
Fix warning on redefinition of BOOST_TEST_DYN_LINK

### DIFF
--- a/test/suite.cpp
+++ b/test/suite.cpp
@@ -1,6 +1,5 @@
 // Do NOT add anything to this file
 // This header from boost takes ages to compile, so we make sure it is compiled
 // only once (here)
-#define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>


### PR DESCRIPTION
Fixes current warning:
test/suite.cpp:4:0: warning: "BOOST_TEST_DYN_LINK" redefined [enabled by default]
 #define BOOST_TEST_DYN_LINK
 ^
