### PR TITLE
Readme as mainpage

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -155,13 +155,6 @@ QT_AUTOBRIEF           = NO
 
 MULTILINE_CPP_IS_BRIEF = NO
 
-# If the DETAILS_AT_TOP tag is set to YES then Doxygen 
-# will output the detailed description near the top, like JavaDoc.
-# If set to NO, the detailed description appears after the member 
-# documentation.
-
-DETAILS_AT_TOP         = NO
-
 # If the INHERIT_DOCS tag is set to YES (the default) then an undocumented 
 # member inherits the documentation from any documented member that it 
 # re-implements.
@@ -445,12 +438,6 @@ MAX_INITIALIZER_LINES  = 30
 # list will mention the files that were used to generate the documentation.
 
 SHOW_USED_FILES        = YES
-
-# If the sources in your project are distributed over multiple directories 
-# then setting the SHOW_DIRECTORIES tag to YES will show the directory hierarchy 
-# in the documentation. The default is NO.
-
-SHOW_DIRECTORIES       = NO
 
 # Set the SHOW_FILES tag to NO to disable the generation of the Files page.
 # This will remove the Files entry from the Quick Index and from the 
@@ -759,11 +746,6 @@ HTML_FOOTER            =
 
 HTML_STYLESHEET        = 
 
-# If the HTML_ALIGN_MEMBERS tag is set to YES, the members of classes, 
-# files or namespaces will be aligned in HTML using tables. If set to 
-# NO a bullet list will be used.
-
-HTML_ALIGN_MEMBERS     = YES
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
 # Microsoft HTML help workshop to generate a compiled HTML help file (.chm) 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -534,7 +534,8 @@ WARN_LOGFILE           =
 # directories like "/usr/src/myproject". Separate the files or directories 
 # with spaces.
 
-INPUT                  = @CMAKE_SOURCE_DIR@/src
+INPUT                   = @CMAKE_SOURCE_DIR@/README.md @CMAKE_SOURCE_DIR@/src
+USE_MDFILE_AS_MAINPAGE  = @CMAKE_SOURCE_DIR@/README.md
 
 # This tag can be used to specify the character encoding of the source files 
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding, which is 
@@ -763,7 +764,6 @@ HTML_STYLESHEET        =
 # NO a bullet list will be used.
 
 HTML_ALIGN_MEMBERS     = YES
-
 # If the GENERATE_HTMLHELP tag is set to YES, additional index files 
 # will be generated that can be used as input for tools like the 
 # Microsoft HTML help workshop to generate a compiled HTML help file (.chm) 

--- a/README.md
+++ b/README.md
@@ -33,23 +33,16 @@ processes and simplify reuse of this project. Following these rules ensures that
 the Rock CMake macros automatically handle the project's build process and
 install setup properly.
 
-STRUCTURE
--- src/ 
-	Contains all header (*.h/*.hpp) and source files
--- build/
-	The target directory for the build process, temporary content
--- bindings/
-	Language bindings for this package, e.g. put into subfolders such as
-   |-- ruby/ 
-        Ruby language bindings
--- viz/
-        Source files for a vizkit plugin / widget related to this library 
--- resources/
-	General resources such as images that are needed by the program
--- configuration/
-	Configuration files for running the program
--- external/
-	When including software that needs a non standard installation process, or one that can be
-	easily embedded include the external software directly here
--- doc/
-	should contain the existing doxygen file: doxygen.conf
+### Folder Structure
+
+| directory         |       purpose                                                        |
+| ----------------- | ------------------------------------------------------               |
+| src/              | Contains all header (*.h/*.hpp) and source files                     |
+| build/ *          | The target directory for the build process, temporary content        |
+| bindings/         | Language bindings for this package, e.g. put into subfolders such as |
+| ruby/             | Ruby language bindings                                               |
+| viz/              | Source files for a vizkit plugin / widget related to this library    |
+| resources/        | General resources such as images that are needed by the program      |
+| configuration/    | Configuration files for running the program                          |
+| external/         | When including software that needs a non standard installation process, or one that can be easily embedded include the external software directly here |
+| doc/              | should contain the existing doxygen file: doxygen.conf               |


### PR DESCRIPTION
Allow a single point of providing documentation and per default use the README.md as mainpage for doxygen