### PR TITLE
call project() at toplevel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 # CMakeLists.txt has to be located in the project folder and cmake has to be
 # executed from 'project/build' with 'cmake ../'.
 cmake_minimum_required(VERSION 3.1)
+project(dummy_project
+        VERSION 0.1
+        DESCRIPTION "dummy-brief-desc")
 find_package(Rock)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-rock_init(dummy_project 0.1)
+rock_init()
 rock_standard_layout()

--- a/config_manifest.sh
+++ b/config_manifest.sh
@@ -77,6 +77,7 @@ if test -e README.md; then
     sed -i "s#dummy-long-desc#$PKG_LONG_DESC#" README.md
 fi
 sed -i "s#dummy-brief-desc#$PKG_DESC#" $MANIFEST
+sed -i "s#dummy-brief-desc#$PKG_DESC#" "CMakeLists.txt"
 sed -i "s#dummy-long-desc#$PKG_LONG_DESC#" $MANIFEST
 sed -i "s#dummy-author#$PKG_AUTHOR#" $MANIFEST
 sed -i "s#dummy-email#$PKG_EMAIL#" $MANIFEST


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-core/base-cmake/pull/58

Ever since CMake 3.0, project() must be called *literally* at
toplevel. Newer version of CMake (in my case 3.16) finally
started to warn about it, but the documentation is clear.

https://cmake.org/cmake/help/v3.0/command/project.html